### PR TITLE
You don't need to specify directory for each step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,11 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    defaults:
+      run:
+        working-directory: frontend
+    env:
+      CI: true
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,18 +37,13 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install frontend deps
-        env:
-          CI: true
-        run: (cd frontend/ && yarn install --frozen-lockfile --cache-folder ~/.cache/yarn)
+        run: yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
 
       - name: Lint frontend
-        env:
-          CI: true
-        run: (cd frontend/ && yarn lint)
+        run: yarn lint
 
       - name: Build frontend
         env:
-          CI: true
           # keep these in sync with compose!
           host: "0.0.0.0"
           publicHost: "https://hangar-auth.benndorf.dev"
@@ -56,7 +55,7 @@ jobs:
           hydraAdmin: "http://hydra:4445"
           hangarHost: "https://hangar.benndorf.dev"
           DEBUG: "nuxt:*"
-        run: (cd frontend/ && yarn build)
+        run: yarn build
 
       - name: SSH
         uses: webfactory/ssh-agent@v0.5.2
@@ -75,6 +74,7 @@ jobs:
           SECRET_KEY: ${{ secrets.SECRET_KEY }}
           POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
           POSTGRES_PW: ${{ secrets.POSTGRES_PW }}
+        working-directory: .
         run: |
           echo ${{ secrets.DOCKER_HOST_SSH_SIG }} > ~/.ssh/known_hosts
           cd docker/deployment


### PR DESCRIPTION
You can instead decide to set a default directory for all `run` steps: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_iddefaultsrun

If this is not acceptable, might want to use `working-directory` on each step instead of `cd`, to keep it a bit cleaner :)