### PR TITLE
fix: settings icon cors issue

### DIFF
--- a/backend/src/main/java/io/papermc/hangarauth/config/WebConfig.java
+++ b/backend/src/main/java/io/papermc/hangarauth/config/WebConfig.java
@@ -1,5 +1,13 @@
 package io.papermc.hangarauth.config;
 
+import io.papermc.hangarauth.config.custom.GeneralConfig;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,16 +20,6 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import java.io.IOException;
-import java.util.List;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import io.papermc.hangarauth.config.custom.GeneralConfig;
-
 @EnableWebMvc
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
@@ -29,20 +27,20 @@ public class WebConfig implements WebMvcConfigurer {
     private final GeneralConfig generalConfig;
 
     @Autowired
-    public WebConfig(GeneralConfig generalConfig) {
+    public WebConfig(final GeneralConfig generalConfig) {
         this.generalConfig = generalConfig;
     }
 
     @Bean
-    public RestTemplate restTemplate(List<HttpMessageConverter<?>> messageConverters) {
-        RestTemplate restTemplate = new RestTemplate();
+    public RestTemplate restTemplate(final List<HttpMessageConverter<?>> messageConverters) {
+        final RestTemplate restTemplate = new RestTemplate();
         restTemplate.setMessageConverters(messageConverters);
         return restTemplate;
     }
 
     @Override
-    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
-        converters.add(byteArrayHttpMessageConverter());
+    public void extendMessageConverters(final List<HttpMessageConverter<?>> converters) {
+        converters.add(this.byteArrayHttpMessageConverter());
     }
 
     @Bean
@@ -56,7 +54,7 @@ public class WebConfig implements WebMvcConfigurer {
     public Filter identifyFilter() {
         return new OncePerRequestFilter() {
             @Override
-            protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+            protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response, final FilterChain filterChain) throws ServletException, IOException {
                 response.setHeader("Server", "HangarAuth");
                 filterChain.doFilter(request, response);
             }
@@ -72,8 +70,11 @@ public class WebConfig implements WebMvcConfigurer {
     }
 
     @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/avatar/**").allowedOrigins(generalConfig.allowedOrigins());
-        registry.addMapping("/image/**").allowedOrigins(generalConfig.allowedOrigins());
+    public void addCorsMappings(final CorsRegistry registry) {
+        final String[] avatarCorsOrigins = new String[this.generalConfig.allowedOrigins().length + 1];
+        avatarCorsOrigins[0] = this.generalConfig.publicHost();
+        System.arraycopy(this.generalConfig.allowedOrigins(), 0, avatarCorsOrigins, 1, avatarCorsOrigins.length - 1);
+        registry.addMapping("/avatar/**").allowedOrigins(avatarCorsOrigins);
+        registry.addMapping("/image/**").allowedOrigins(this.generalConfig.allowedOrigins());
     }
 }

--- a/backend/src/main/java/io/papermc/hangarauth/config/custom/GeneralConfig.java
+++ b/backend/src/main/java/io/papermc/hangarauth/config/custom/GeneralConfig.java
@@ -9,6 +9,6 @@ public record GeneralConfig(
     @DefaultValue("supersecret2") String apiKey,
     @DefaultValue("http://localhost:3333") String hangarFrontendHost,
     @DefaultValue("http://localhost:3333") String hangarBackendHost,
-    @DefaultValue("http://localhost:3000") String[] allowedOrigins
+    @DefaultValue({"http://localhost:3000", "http://localhost:3333"}) String[] allowedOrigins
 ) {
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,7 +6,9 @@ auth:
   api-key: "supersecret"
   hangar-frontend-host: "http://localhost:3333"
   hangar-backend-host: "http://localhost:3333"
-  allowed-origins: "http://localhost:3000, http://localhost:3001"
+  allowed-origins:
+    - "http://localhost:3000"
+    - "http://localhost:3333"
   kratos:
     public-url: "http://localhost:4433"
     public-backend-url: "http://localhost:4433"


### PR DESCRIPTION
In the settings.vue page on Hangar, the image is loaded into the cropper without being proxied. This means that Hangar makes a direct request to the auth host for the user's avatar, but it wasn't in the allowed origins. I think this also affects the hangarcdn host as there are errors when [this page is loading](https://hangar.papermc.dev/Phoenix616/Test/settings). I don't know where the cors is configured for that though, so this just fixes it for local instances.

<img width="1516" alt="image" src="https://user-images.githubusercontent.com/15055071/209451094-69f66b67-99db-4225-a9c2-c24cbc1a4a4c.png">
